### PR TITLE
Distance label in UI

### DIFF
--- a/src/KVrVesselShot.cs
+++ b/src/KVrVesselShot.cs
@@ -60,7 +60,8 @@ namespace KronalUtils
             { "shadowVal", 0f }, { "shadowValPercent", 0f },
             {"imgPercent",4f},
             {"bgR",1f},{"bgG",1f},{"bgB",1f},{"bgA",1f},//RGBA
-            {"bgR_",0f},{"bgG_",0.07f},{"bgB_",0.11f},{"bgA_",1f}//RGBA defaults //00406E 0,64,110 -> reduced due to color adjust shader
+            {"bgR_",0f},{"bgG_",0.07f},{"bgB_",0.11f},{"bgA_",1f},//RGBA defaults //00406E 0,64,110 -> reduced due to color adjust shader
+            {"distance",1f}
         };
         public Dictionary<string, bool> uiBoolVals = new Dictionary<string, bool> {
             {"canPreview",true},{"saveTextureEvent",false}
@@ -379,6 +380,7 @@ namespace KronalUtils
 
             this.Camera.transform.Translate(new Vector3(this.position.x, this.position.y, -positionOffset));
             float distanceToShip = Vector3.Distance(this.Camera.transform.position, this.shipBounds.center);
+            uiFloatVals["distance"] = distanceToShip;
             this.Camera.farClipPlane = distanceToShip + this.Camera.nearClipPlane + depth * 2 + 1; // 1 for the first rotation vector
             
             if (this.Orthographic)

--- a/src/KVrVesselShotUI.cs
+++ b/src/KVrVesselShotUI.cs
@@ -291,6 +291,12 @@ namespace KronalUtils
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
+            GUILayout.Label("Distance", GUILayout.Width(68f));
+            GUILayout.Space(1f);
+            GUILayout.Label(control.uiFloatVals["distance"].ToString("F"), GUILayout.Width(50f));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
             this.shaderTabCurrent = GUILayout.Toolbar(this.shaderTabCurrent, this.shaderTabsNames);
             GUILayout.EndHorizontal();
             


### PR DESCRIPTION
Adds a label to the UI under the camera buttons showing camera distance to ship. Allows consistent scaling of screenshots.

Using the zoom buttons is imprecise. It would be nice to be able to input the scale directly.