### PR TITLE
Logging overhaul for consistency

### DIFF
--- a/src/BundleIndex.cs
+++ b/src/BundleIndex.cs
@@ -1,18 +1,13 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.IO;
 using UnityEngine;
-using KSP;
-using KSPAssets;
 
 namespace KronalUtils
 {
     class BundleIndex : MonoBehaviour
     {
-        
+
         //KSPAssets.AssetDefinition[] KVrShaders = KSPAssets.Loaders.AssetLoader.GetAssetDefinitionsWithType(KronalUtils.Properties.Resources.ShaderFXAA, typeof(Shader));
         /*
         public Dictionary<string, string> ShaderData = new Dictionary<string, string> { 
@@ -22,14 +17,14 @@ namespace KronalUtils
             { "MaterialBluePrint", KSP.IO.File.ReadAllText<KVrVesselShot>("blueprint") }, 
         };*/
         internal static Dictionary<string, Font> loadedFonts = new Dictionary<string, Font>();
-       // internal static Dictionary<string, Shader> loadedShaders = new Dictionary<string, Shader>();
+        // internal static Dictionary<string, Shader> loadedShaders = new Dictionary<string, Shader>();
         /*public Dictionary<string, string> ShaderData = new Dictionary<string, string> {
             { "MaterialFXAA", "KVV/Hidden/SlinDev/Desktop/PostProcessing/FXAA" },
             { "MaterialColorAdjust", "KVV/Color Adjust" },
             { "MaterialEdgeDetect", "Hidden/Edge Detect Normals2" },
         };*/
-      //  public Dictionary<string, KSPAssets.Loaders.AssetLoader> KVrShaders = new Dictionary<string, KSPAssets.Loaders.AssetLoader>();
-      //  public Dictionary<string, KSPAssets.Loaders.AssetLoader> KVrShaders2 = new Dictionary<string, KSPAssets.Loaders.AssetLoader>();
+        //  public Dictionary<string, KSPAssets.Loaders.AssetLoader> KVrShaders = new Dictionary<string, KSPAssets.Loaders.AssetLoader>();
+        //  public Dictionary<string, KSPAssets.Loaders.AssetLoader> KVrShaders2 = new Dictionary<string, KSPAssets.Loaders.AssetLoader>();
         public BundleIndex()
         {
             /*
@@ -40,13 +35,13 @@ namespace KronalUtils
                 {"FXAA", MaterialFXAA}
             };*/
             //KSPAssets.AssetDefinition[] KVrShaders = KSPAssets.Loaders.AssetLoader.GetAssetDefinitionsWithType(KronalUtils.Properties.Resources.ShaderFXAA, typeof(Shader));
-            
+
 
 
             InitShaders();
         }
 
-        public  bool BundleLoaded = false;
+        public bool BundleLoaded = false;
         public static Dictionary<string, Shader> LoadedShaders = new Dictionary<string, Shader>();
         private IEnumerator coroutine;
 
@@ -55,16 +50,15 @@ namespace KronalUtils
         {
             if (BundleLoaded)
                 return;
-            Debug.Log("LoadBundle");
+            log.debug("LoadBundle");
             coroutine = doLoadBundle();
-            
+
             StartCoroutine(coroutine);
         }
         IEnumerator doLoadBundle()
-        { 
+        {
+            log.debug(string.Format("Application.platform: {0}", Application.platform));
             string bundleName;
-            Debug.Log("Application.platform: " + Application.platform.ToString());
-
             switch (Application.platform)
             {
                 case RuntimePlatform.OSXPlayer:
@@ -78,12 +72,12 @@ namespace KronalUtils
                 case RuntimePlatform.WindowsPlayer:
                     if (SystemInfo.graphicsDeviceVersion.Contains("OpenGL"))
                     {
-                        Debug.Log("OpenGL found");
+                        log.debug("OpenGL found");
                         bundleName = "shaders.windows.opengl.bundle";
                     }
                     else
                     {
-                        Debug.Log("Not OpenGL");
+                        log.debug("Not OpenGL");
                         bundleName = "shaders.windows.bundle";
                     }
 
@@ -94,12 +88,12 @@ namespace KronalUtils
                     break;
             }
 
-            Debug.Log("Loading shader bundle file: " + bundleName);
+            log.debug(string.Format("Loading shader bundle file: {0}", bundleName));
             WWW www = new WWW("file://" + KSPUtil.ApplicationRootPath + "GameData/KronalUtils/Resources/" + bundleName);
             yield return www;
             {
                 if (www.error != null)
-                    Debug.Log("Shaders bundle not found!");
+                    log.error("Shaders bundle not found");
 
                 AssetBundle bundle = www.assetBundle;
 
@@ -107,7 +101,7 @@ namespace KronalUtils
 
                 foreach (Shader shader in shaders)
                 {
-                    Debug.Log("Shader " + shader.name + " is loaded");
+                    log.debug(string.Format("Found shader {0} in asset bundle", shader.name));
                     LoadedShaders.Add(shader.name, shader);
                 }
 
@@ -122,32 +116,28 @@ namespace KronalUtils
         private void InitShaders()
         {
             LoadBundle();
+
 #if false
-#if DEBUG
-            Debug.Log(string.Format("KVV: InitShaders 1: {0}", KSPAssets.Loaders.AssetLoader.ApplicationRootPath));
-#endif
-            
+            log.debug(string.Format("InitShaders 1: {0}", KSPAssets.Loaders.AssetLoader.ApplicationRootPath));
+
             string KVrPath = KVrUtilsCore.ModRoot();
-            Debug.Log("KVrPath: " + KVrPath);
+            log.debug(string.Format("KVrPath: {0}", KVrPath));
 
             string KVrAssetPath = Path.GetDirectoryName(KVrPath + Path.DirectorySeparatorChar);
-            Debug.Log("KVrAssetPath: " + KVrAssetPath);
+            log.debug(string.Format("KVrAssetPath: {0}", KVrAssetPath));
             KVrAssetPath = "KronalUtils";
-#if DEBUG
-            Debug.Log(string.Format("KVV: InitShaders 2 KVrPath{0} \n\t- Directory  Path.GetFileName( KVrAssetPath ...) {1} ", KVrPath, Path.GetFileName(KVrAssetPath + Path.DirectorySeparatorChar + "kvv")));//, String.Join("\n\t- ", System.IO.Directory.GetFiles(KVrPath))
-#endif
+            log.debug(string.Format("InitShaders 2 KVrPath{0} \n\t- Directory  Path.GetFileName( KVrAssetPath ...) {1} ", KVrPath, Path.Combine(KVrAssetPath, "kvv")));
+            //, String.Join("\n\t- ", System.IO.Directory.GetFiles(KVrPath))
             KSPAssets.AssetDefinition[] KVrShaders = KSPAssets.Loaders.AssetLoader.GetAssetDefinitionsWithType(KVrAssetPath + "/kvv", typeof(Shader));//path to kvv.ksp
             if (KVrShaders == null || KVrShaders.Length == 0)
             {
-                Debug.Log(string.Format("KVV: Failed to load Asset Package KronalUtils/kvv.ksp in {0}.", KVrPath));
+                log.error(string.Format("Failed to load Asset Package KronalUtils/kvv.ksp in {0}.", KVrPath));
                 return;
             }else {
                 KSPAssets.Loaders.AssetLoader.LoadAssets(ShadersLoaded, KVrShaders[0]);
             }
-            
-#if DEBUG
-            Debug.Log(string.Format("KVV: InitShaders 4"));
-#endif
+
+            log.debug(string.Format("InitShaders 4"));
             /*
             foreach (KeyValuePair<string, string> itKey in ShaderData)
             {
@@ -166,9 +156,7 @@ namespace KronalUtils
 #if false
         private void ShadersLoaded(KSPAssets.Loaders.AssetLoader.Loader loader) // thanks moarDV - https://github.com/Mihara/RasterPropMonitor/blob/5c9fa8b259dd391892fe121724519413ccbb6b59/RasterPropMonitor/Core/UtilityFunctions.cs
         {
-#if DEBUG
-            Debug.Log(string.Format("KVV: ShadersLoaded"));
-#endif
+            log.debug(string.Format("ShadersLoaded"));
             string aShaderName = string.Empty;
             for (int i = 0; i < loader.objects.Length; ++i)
             {
@@ -184,14 +172,14 @@ namespace KronalUtils
 
             if (string.IsNullOrEmpty(aShaderName))
             {
-                Debug.Log(string.Format("KVV: Unable to find a named shader \"{0}\".", aShaderName));
+                log.warning(string.Format("Unable to find a named shader \"{0}\".", aShaderName));
                 return;
             }
 
             var loadedBundles = KSPAssets.Loaders.AssetLoader.LoadedBundles;
             if (loadedBundles == null)
             {
-                Debug.Log(string.Format("KVV: Unable to find any loaded bundles in AssetLoader."));
+                log.warning(string.Format("Unable to find any loaded bundles in AssetLoader."));
                 return;
             }
 
@@ -235,24 +223,20 @@ namespace KronalUtils
                     {
                         if (!shaders[j].isSupported)
                         {
-#if DEBUG
-                            Debug.Log(string.Format("KVV: Shader {0} - unsupported in this configuration", shaders[j].name));
-#endif
+                            log.debug(string.Format("Shader {0} - unsupported in this configuration", shaders[j].name));
                         }
                         loadedShaders[shaders[j].name] = shaders[j];
                     }
                     for (int j = 0; j < fonts.Length; ++j)
                     {
-#if DEBUG
-                        Debug.Log(string.Format("KVV: Adding KSP-Bundle-included font {0} / {1}", fonts[j].name, fonts[j].fontSize));
-#endif
+                        log.debug(string.Format("Adding KSP-Bundle-included font {0} / {1}", fonts[j].name, fonts[j].fontSize));
                         loadedFonts[fonts[j].name] = fonts[j];
                     }
                     return;
                 }
             }
 
-            Debug.Log(string.Format("KVV: Failed to load shaders  - how did this callback execute?"));
+            log.error(string.Format("Failed to load shaders  - how did this callback execute?"));
         }
 #endif
     }

--- a/src/EditorLockManager.cs
+++ b/src/EditorLockManager.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace KronalUtils
 {

--- a/src/KSVersion.cs
+++ b/src/KSVersion.cs
@@ -107,7 +107,7 @@ namespace KerbalStuffVersion_BOM
             }
             catch (Exception e)
             {
-                Debug.LogError(e.Message);
+                log.error(e.Message);
                 return null;
             }
             finally

--- a/src/KVrEditorAxis.cs
+++ b/src/KVrEditorAxis.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.IO;
 using UnityEngine;
 
 namespace KronalUtils
@@ -38,9 +34,7 @@ namespace KronalUtils
             CreateLineMaterial();
             this.evo = (EditorVesselOverlays)GameObject.FindObjectOfType(typeof(EditorVesselOverlays));
 
-#if DEBUG
-            Debug.Log(string.Format("KVV: KVrEditorAxis Awake"));
-#endif
+            log.debug(string.Format("KVrEditorAxis Awake"));
         }
         public void OnEnable()
         {

--- a/src/KVrUtils.cs
+++ b/src/KVrUtils.cs
@@ -1,15 +1,31 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
-using System.IO;
 using UnityEngine;
-using KSP;
 
 namespace KronalUtils
 {
+    // Simple utility method for debugging output
+    public static class log {
+        [Conditional("DEBUG")]
+        public static void debug(string message) {
+            string template = "[KVV] {0}";
+            UnityEngine.Debug.Log(string.Format(template, message));
+        }
+
+        public static void warn(string message) {
+            string template = "[KVV] {0}";
+            UnityEngine.Debug.LogWarning(string.Format(template, message));
+        }
+
+        public static void error(string message) {
+            string template = "[KVV] {0}";
+            UnityEngine.Debug.LogError(string.Format(template, message));
+        }
+    }
+
+
     static class KRSHelper
     {
         public static T Module<T>(this Part part) where T : PartModule
@@ -33,7 +49,7 @@ namespace KronalUtils
             var stopwatch = e.Value;
             stopwatch.Stop();
             TimeSpan ts = stopwatch.Elapsed;
-            string elapsedTime = String.Format("{0:00}:{1:00}:{2:00}.{3:000}",
+            string elapsedTime = string.Format("{0:00}:{1:00}:{2:00}.{3:000}",
                 ts.Hours, ts.Minutes, ts.Seconds,
                 ts.Milliseconds);
             //MonoBehaviour.print("[DEBUG] Event: " + name + "   DT: " + elapsedTime);

--- a/src/KVrUtilsCore.cs
+++ b/src/KVrUtilsCore.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 using UnityEngine;
-using KSP;
-using KSPAssets;
 
 namespace KronalUtils
 {
@@ -13,8 +7,8 @@ namespace KronalUtils
     class KVrUtilsCore : MonoBehaviour
     {
         public static BundleIndex AssetIndex;
-        public static string ModPath = Path.Combine(System.IO.Directory.GetParent(KSPUtil.ApplicationRootPath).ToString() + Path.DirectorySeparatorChar + "GameData" + Path.DirectorySeparatorChar, "KronalUtils");
-        public static string SavePath = Path.Combine(System.IO.Directory.GetParent(KSPUtil.ApplicationRootPath).ToString(), "Screenshots");
+        public static string ModPath = Path.Combine(Directory.GetParent(KSPUtil.ApplicationRootPath).ToString() + Path.DirectorySeparatorChar + "GameData" + Path.DirectorySeparatorChar, "KronalUtils");
+        public static string SavePath = Path.Combine(Directory.GetParent(KSPUtil.ApplicationRootPath).ToString(), "Screenshots");
         private void Awake()
         {
              AssetIndex = gameObject.AddComponent<BundleIndex>(); // new BundleIndex();

--- a/src/KVrVesselShot.cs
+++ b/src/KVrVesselShot.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using UnityEngine;
-using KSP;
-using KSPAssets;
-
 
 namespace KronalUtils
 {
@@ -184,17 +178,13 @@ namespace KronalUtils
             //if (HighLogic.LoadedScene == GameScenes.SPH)
             if (editorOrientation == "SPH")
             {
-#if DEBUG
-                Debug.Log(string.Format("Rotating in SPH: {0}", degrees));
-#endif
+                log.debug(string.Format("Rotating in SPH: {0}", degrees));
                 //rotateAxis = EditorLogic.startPod.transform.forward;
                 rotateAxis = EditorLogic.RootPart.transform.forward;
             }
             else
             {
-#if DEBUG
-                Debug.Log(string.Format("Rotating in VAB: {0}", degrees));
-#endif
+                log.debug(string.Format("Rotating in VAB: {0}", degrees));
                 //rotateAxis = EditorLogic.startPod.transform.up;
                 rotateAxis = EditorLogic.RootPart.transform.up;
             }
@@ -221,7 +211,7 @@ namespace KronalUtils
             {
                 var mat = new Material(s.Value);
                 Materials.Add(mat.shader.name, mat);
-                //Materials[mat.shader.name] = mat;
+                log.debug(string.Format("Found shader: {0}", mat.shader.name));
             }
             
 #if false
@@ -230,15 +220,12 @@ namespace KronalUtils
                 try
                 {
                     var mat = new Material(KVrUtilsCore.AssetIndex.gettShaderById(shaderFilename));
-                    Debug.Log("Material: " + shaderFilename + " loaded");
+                    log.debug(string.Format("Material: {0} loaded", shaderFilename));
                     Materials[mat.shader.name] = mat;
                 }
                 catch
                 {
-                    //MonoBehaviour.print("[ERROR] " + this.GetType().Name + " : Failed to load " + shaderFilename);
-#if DEBUG
-                    Debug.Log(string.Format("KVV: LoadShaders [ERROR] " + this.GetType().Name + " : Failed to load " + shaderFilename));
-#endif
+                    log.error(string.Format("LoadShaders {0} : Failed to load {1}", this.GetType().Name, shaderFilename));
                 }
             }
 #endif
@@ -254,17 +241,15 @@ namespace KronalUtils
             foreach (MeshRenderer mr in model.GetComponentsInChildren<MeshRenderer>())
             {
                 Material mat;
-                if (Materials.TryGetValue(mr.material.shader.name, out mat))
+                Materials.TryGetValue(mr.material.shader.name, out mat);
+                if (mat)
                 {
                     if (!MeshRendererLibrary.ContainsKey(mr)) {
                         MeshRendererLibrary.Add(mr, mr.material.shader);
                     }
                     mr.material.shader = mat.shader;
                 } else {
-                    //MonoBehaviour.print("[Warning] " + this.GetType().Name + "No replacement for " + mr.material.shader + " in " + part + "/*/" + mr);
-#if DEBUG
-                    Debug.Log(string.Format("KVV: LoadShaders [Warning] " + this.GetType().Name + " No replacement for " + mr.material.shader + " in " + part + "/*/" + mr));
-#endif
+                    log.warn(string.Format("LoadShaders {0} No replacement for {1} in {2}/*/{3}", this.GetType().Name, mr.material.shader, part, mr));
                 }
             }
             if (!PartShaderLibrary.ContainsKey(part))
@@ -445,7 +430,7 @@ namespace KronalUtils
                         }
                     }
                     else
-                        Debug.Log("fx.Value.Material is null: " + fx.Key);
+                        log.debug(string.Format("fx.Value.Material is null: {0}", fx.Key));
                 }
             }
 
@@ -467,9 +452,7 @@ namespace KronalUtils
         {
             int fileWidth = this.rt.width;
             int fileHeight = this.rt.height;
-#if DEBUG
-            Debug.Log(string.Format("KVV: SIZE: {0} x {1}", fileWidth, fileHeight));
-#endif
+            log.debug(string.Format("SIZE: {0} x {1}", fileWidth, fileHeight));
 
             Texture2D screenShot = new Texture2D(fileWidth, fileHeight, TextureFormat.ARGB32, false);
             
@@ -492,7 +475,7 @@ namespace KronalUtils
             } while(File.Exists(filename));
             System.IO.File.WriteAllBytes(filename, bytes);
 
-            Debug.Log(string.Format("KVV: Took screenshot to: {0}", filename));
+            log.debug(string.Format("Took screenshot to: {0}", filename));
             screenShot = null;
             bytes = null;
         }

--- a/src/KVrVesselShotUI.cs
+++ b/src/KVrVesselShotUI.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using UnityEngine;
 using KSP.UI.Screens;
 
@@ -284,7 +282,7 @@ namespace KronalUtils
             GUILayout.Space(1f);
             String disW = Math.Floor((control.uiFloatVals["imgPercent"] +1) * control.calculatedWidth).ToString();
             String disH = Math.Floor((control.uiFloatVals["imgPercent"] + 1) * control.calculatedHeight).ToString();
-            GUILayout.Label(String.Format("{0:0.#}", this.control.uiFloatVals["imgPercent"].ToString("F")) + "\n" + disW + " x " + disH, GUILayout.Width(110f));
+            GUILayout.Label(string.Format("{0:0.#}", this.control.uiFloatVals["imgPercent"].ToString("F")) + "\n" + disW + " x " + disH, GUILayout.Width(110f));
             control.uiFloatVals["imgPercent"] = control.uiFloatVals["imgPercent"] + 1;
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
@@ -431,9 +429,7 @@ namespace KronalUtils
 
         void OnGUIAppLauncherReady()
         {
-#if DEBUG
-            Debug.Log(string.Format("KVV: OnGUIAppLauncherReady {0}", KSP.UI.Screens.ApplicationLauncher.Ready.ToString()));
-#endif
+            log.debug(string.Format("OnGUIAppLauncherReady {0}", KSP.UI.Screens.ApplicationLauncher.Ready));
             if (KSP.UI.Screens.ApplicationLauncher.Ready)
             {
                 
@@ -469,9 +465,7 @@ namespace KronalUtils
 
         void OnDestroy()
         {
-#if DEBUG
-            Debug.Log(string.Format("KVV: OnDestroy"));
-#endif
+            log.debug("OnDestroy");
             GameEvents.onGUIApplicationLauncherReady.Remove(OnGUIAppLauncherReady);
             if (this.axis != null)
                 EditorLogic.DestroyObject(this.axis);

--- a/src/KronalUtils.csproj
+++ b/src/KronalUtils.csproj
@@ -21,6 +21,15 @@
     <DefineConstants>TRACE;DEBUG;KAS KERAMZIT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CustomCommands>
+      <CustomCommands>
+        <Command>
+          <type>AfterBuild</type>
+          <command>/bin/sh deploy.sh ${TargetFile}</command>
+          <workingdir>${SolutionDir}</workingdir>
+        </Command>
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,9 +44,10 @@
     <OutputPath>bin\DebugNoProceduralFairingsKAS\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <WarningLevel>4</WarningLevel>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyFileVersion1.cs">
@@ -90,28 +100,26 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>R:\KSP_1.1.4_dev\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\Library\Application Support\Steam\SteamApps\common\Kerbal Space Program\KSP.app\Contents\Resources\Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>R:\KSP_1.1.4_dev\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>..\..\..\Library\Application Support\Steam\SteamApps\common\Kerbal Space Program\KSP.app\Contents\Resources\Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="KAS">
-      <HintPath>R:\KSP_1.1.4_dev\GameData\KAS\Plugins\KAS.dll</HintPath>
+      <HintPath>..\..\..\Library\Application Support\Steam\SteamApps\common\Kerbal Space Program\GameData\KAS\Plugins\KAS.dll</HintPath>
     </Reference>
     <Reference Include="KSPAssets">
-      <HintPath>R:\KSP_1.1.4_dev\KSP_x64_Data\Managed\KSPAssets.dll</HintPath>
+      <HintPath>..\..\..\Library\Application Support\Steam\SteamApps\common\Kerbal Space Program\KSP.app\Contents\Resources\Data\Managed\KSPAssets.dll</HintPath>
     </Reference>
     <Reference Include="ProceduralFairings">
-      <HintPath>R:\KSP_1.1.4_dev\GameData\ProceduralFairings\ProceduralFairings.dll</HintPath>
+      <HintPath>..\..\..\Downloads\ProcFairings_3.20\GameData\ProceduralFairings\ProceduralFairings.dll</HintPath>
     </Reference>
-    <Reference Include="System">
-      <HintPath>R:\KSP_1.1.4_dev\KSP_x64_Data\Managed\System.dll</HintPath>
-    </Reference>
+    <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>R:\KSP_1.1.4_dev\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\Library\Application Support\Steam\SteamApps\common\Kerbal Space Program\KSP.app\Contents\Resources\Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>R:\KSP_1.1.4_dev\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\Library\Application Support\Steam\SteamApps\common\Kerbal Space Program\KSP.app\Contents\Resources\Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -125,20 +133,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>set textTemplatingPath="%25CommonProgramFiles(x86)%25\Microsoft Shared\TextTemplating\$(VisualStudioVersion)\texttransform.exe"
-
-if %25textTemplatingPath%25=="\Microsoft Shared\TextTemplating\$(VisualStudioVersion)\texttransform.exe" set textTemplatingPath="%25CommonProgramFiles%25\Microsoft Shared\TextTemplating\$(VisualStudioVersion)\texttransform.exe"
-
-%25textTemplatingPath%25 "$(ProjectDir)AssemblyFileVersion.tt"
-</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>start /D D:\Users\jbb\github\ksp-kronalutils /WAIT deploy.bat
-
-if $(ConfigurationName) == Release (
-start /D D:\Users\jbb\github\ksp-kronalutils /WAIT buildRelease.bat
-)
-</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/MaterialProperties.cs
+++ b/src/MaterialProperties.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
@@ -180,14 +177,14 @@ namespace KronalUtils
         public ShaderMaterial(string fileName, string contentName)
             : this()
         {
-            Debug.Log("Enter ShaderMaterial, filename: " + fileName + "   contentName: " + contentName);
+            log.debug(string.Format("Enter ShaderMaterial, filename: {0}   contentName: {1}", fileName, contentName));
             string contents;
             try
             {
                 this.Material = new Material(KVrUtilsCore.getShaderById(contentName));
             } catch (Exception e)
             {
-                Debug.Log("Error: " + e.ToString() + " creating material: " + fileName);
+                log.error(string.Format("{0} creating material: {1}", e, fileName));
                 return;
 
             }
@@ -197,7 +194,7 @@ namespace KronalUtils
                 contents = System.IO.File.ReadAllText(KSPUtil.ApplicationRootPath + "GameData/KronalUtils/Resources/" + fileName + ".shader");
             } catch (Exception e)
             {
-                Debug.Log("Error: " + e.ToString() + " reading file: " + fileName);
+                log.error(string.Format("{0} reading file: {1}", e, fileName));
                 return;
             }
 
@@ -207,15 +204,12 @@ namespace KronalUtils
             var m = Regex.Match(contents, p, RegexOptions.Multiline | RegexOptions.IgnoreCase);
             if (!m.Success)
             {
-                throw new Exception("Error parsing shader properties: " + this.Material.shader.name);
+                throw new Exception(string.Format("Error parsing shader properties: {0}", this.Material.shader.name));
             }
             p = @"(?<name>\w*)\s*\(\s*""(?<displayname>[^""]*)""\s*,\s*(?<type>Float|Vector|Color|2D|Rect|Cube|Range\s*\(\s*(?<rangemin>[\d.]*)\s*,\s*(?<rangemax>[\d.]*)\s*\))\s*\)";
 
-                
-#if DEBUG
-            //Debug.Log(string.Format("KVV: ShaderMaterial1 " + m.Value));
-#endif
-            
+            log.debug(string.Format("ShaderMaterial1 {0}", m.Value));
+
             foreach(Match match in Regex.Matches(m.Value, p))
             {
                 ShaderMaterialProperty prop;
@@ -242,8 +236,8 @@ namespace KronalUtils
                 this.properties.Add(prop);
                 this.propertiesByName[prop.Name] = prop;
             }
-            Debug.Log("Enter ShaderMaterial, filename: " + fileName + "   contentName: " + contentName + "   properties.count: " + properties.Count.ToString());
-   
+            log.debug(string.Format("Enter ShaderMaterial, filename: {0} contentName: {1} properties.count: {2}", fileName, contentName, properties.Count));
+
         }
 
         public ShaderMaterial Clone()

--- a/src/VesselViewConfig.cs
+++ b/src/VesselViewConfig.cs
@@ -92,7 +92,7 @@ namespace KronalUtils
             foreach (AssemblyLoader.LoadedAssembly a in AssemblyLoader.loadedAssemblies)
             {
                 string name = a.name;
-                //UnityEngine.Debug.Log(string.Format("KVV: name: {0}", name));//future debubging
+                log.debug(string.Format("Loading assembly: {0}", name));
                 installedMods.Add(name);
             }
         }
@@ -104,7 +104,7 @@ namespace KronalUtils
         //constructor
         public VesselViewConfig()
         {
-            Debug.Log("VesselViewConfig");
+            log.debug("VesselViewConfig");
             buildModList();
             this.positions = new Dictionary<Transform, Vector3>();
             this.visibility = new Dictionary<Renderer, bool>();
@@ -188,7 +188,7 @@ namespace KronalUtils
                         new VesselElementViewOption("Hide", true, false, PartHideRecursive, true),
                     }
             });
-            Debug.Log("Config list contains: " + Config.Count.ToString());
+            log.debug(string.Format("Config list contains: {0}", Config.Count));
         }
         bool curState = false;
         //updated for simpflication
@@ -263,7 +263,7 @@ namespace KronalUtils
             StateToggle(true);//SaveState();
             foreach (var part in ship.Parts)
             {
-                Debug.Log("Execute, part: " + part.partInfo.title);
+                log.debug(string.Format("Execute, part: {0}", part.partInfo.title));
                 if (part.Modules.Contains("ModuleProceduralFairing"))
                 {
                     StockProcFairing_st_idle_replacement(true, part);
@@ -335,7 +335,7 @@ namespace KronalUtils
 
                             foreach (var s in States)
                             {
-                                Debug.Log("KFSMState name: " + s.name);
+                                log.debug(string.Format("KFSMState name: {0}", s.name));
                                 if (s.name == "st_idle")
                                 {
                                     if (save)
@@ -378,7 +378,7 @@ namespace KronalUtils
 
         private void StockProceduralFairingToggleState(Boolean toggleOn, Part part)
         {
-            Debug.Log("StockProceduralFairingToggleState");
+            log.debug("StockProceduralFairingToggleState");
 
             if (part.Modules.Contains("ModuleProceduralFairing"))
             {
@@ -406,7 +406,7 @@ namespace KronalUtils
 
         private void PartHide(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            //MonoBehaviour.print("Hiding Part " + part.ToString());
+            log.debug(string.Format("Hiding Part {0}", part));
             foreach (var r in part.GetComponents<Renderer>())
             {
                 r.enabled = false;
@@ -415,7 +415,7 @@ namespace KronalUtils
 
         private void PartHideRecursive(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            //MonoBehaviour.print("Hiding Part " + part.ToString());
+            log.debug(string.Format("Hiding Part {0}", part));
             foreach (var r in part.GetComponentsInChildren<Renderer>())
             {
                 r.enabled = false;
@@ -424,7 +424,7 @@ namespace KronalUtils
 
         private void StackDecouplerExplode(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            //MonoBehaviour.print("Exploding Stack Decoupler: " + part.ToString());
+            log.debug(string.Format("Exploding Stack Decoupler: {0}", part));
             var module = part.Module<ModuleDecouple>();
             if (module.isDecoupled) return;
             if (!module.staged) return; // don't explode if tweakable staging is false
@@ -445,7 +445,7 @@ namespace KronalUtils
 
         private void RadialDecouplerExplode(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            //MonoBehaviour.print("Exploding Radial Decoupler: " + part.ToString());
+            log.debug(string.Format("Exploding Radial Decoupler: {0}", part));
             var module = part.Module<ModuleAnchoredDecoupler>();
             if (module.isDecoupled) return;
             if (!module.staged) return; // don't explode if tweakable staging is false
@@ -472,7 +472,7 @@ namespace KronalUtils
 
         private void DockingPortExplode(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            //MonoBehaviour.print("Exploding Docking Port: " + part.ToString());
+            log.debug(string.Format("Exploding Docking Port: {0}", part));
             var module = part.Module<ModuleDockingNode>();
             if (string.IsNullOrEmpty(module.referenceAttachNode)) return;
             var an = part.FindAttachNode(module.referenceAttachNode);
@@ -493,7 +493,7 @@ namespace KronalUtils
 
         private void EngineFairingExplode(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            //MonoBehaviour.print("Exploding Engine Fairing: " + part.ToString());
+            log.debug(string.Format("Exploding Engine Fairing: {0}", part));
             var module = part.Module<ModuleJettison>();
             if (!module.isJettisoned)
             {
@@ -506,7 +506,7 @@ namespace KronalUtils
 
         private void EngineFairingHide(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            //MonoBehaviour.print("Hiding Engine Fairing: " + part.ToString());
+            log.debug(string.Format("Hiding Engine Fairing: {0}", part));
             var module = part.Module<ModuleJettison>();
             if (module.jettisonTransform)
             {
@@ -552,8 +552,7 @@ namespace KronalUtils
         public static float fairingPanelValueParam;
         private void StockProcFairingExplode(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            //MonoBehaviour.print("Exploding Procedural Fairing: " + part.ToString());
-            Debug.Log("StockProcFairingExplode");
+            log.debug(string.Format("Exploding Procedural Fairing: {0}", part));
             fairingPanels = new List<ProceduralFairings.FairingPanel>();
             var module = part.Module<ModuleProceduralFairing>();
             fairingPanelValueParam = o.valueParam;
@@ -569,7 +568,7 @@ namespace KronalUtils
 
         private void StockProcFairingHide(VesselElementViewOptions ol, VesselElementViewOption o, Part part)
         {
-            MonoBehaviour.print("Hiding StockProcFairingHide Fairing: " + part.ToString());
+            log.debug(string.Format("Hiding StockProcFairingHide Fairing: {0}", part));
             var module = part.Module<ModuleProceduralFairing>();
 
             foreach (var p in module.Panels)
@@ -580,9 +579,9 @@ namespace KronalUtils
         {
             if (hasMod("ProceduralFairings"))
             {
-                //MonoBehaviour.print("Exploding Procedural Fairing: " + part.ToString());
+                log.debug(string.Format("Exploding Procedural Fairing: {0}", part));
                 var nct = part.FindModelTransform("nose_collider");
-                //Debug.Log(string.Format("KVV: ProcFairingExplode {0}", nct.ToString()));
+                log.debug(string.Format("ProcFairingExplode {0}", nct));
                 if (!nct) return;
                 this.procFairingOffset = o.valueParam; // steal the offset value. to be added to vessel width for rendering.
                 //MeshFilter mf;
@@ -596,7 +595,7 @@ namespace KronalUtils
         {
             if (hasMod("ProceduralFairings"))
             {
-                //MonoBehaviour.print("Hiding Procedural Fairing: " + part.ToString());
+                log.debug(string.Format("Hiding Procedural Fairing: {0}", part));
                 var nct = part.FindModelTransform("nose_collider");
                 if (!nct) return;
                 //var forward = EditorLogic.startPod.transform.forward;


### PR DESCRIPTION
I made a number of changes so that logging is more useful and consistent.

* There is now a logging class with static methods for debug, warning, and error messages. Each prepends "[KVV]" to messages, then passes them to Unity's logger. As a result, logging messages from KVV can be reliably identified in the debug console.
* The debug method has a conditional attribute, which prevents debug messages from being called in release builds. It also supplants the inelegant "#if DEBUG" blocks.
* Readability of some code to generate log messages has been improved by replacing + operator concatenation with calls to string.Format.
* A few whitespace changes crept in where my IDE automatically reformatted mistakes. Things like indentations off by one space, or blocks of invisible characters.
* Some unused or unnecessary requirement imports were removed.